### PR TITLE
Replace Xirsys' local region urls with the global (recommended) one

### DIFF
--- a/src/main/kotlin/com/faforever/icebreaker/service/xirsys/XirsysSessionHandler.kt
+++ b/src/main/kotlin/com/faforever/icebreaker/service/xirsys/XirsysSessionHandler.kt
@@ -19,6 +19,11 @@ class XirsysSessionHandler(
 ) : SessionHandler {
     companion object {
         const val SERVER_NAME = "xirsys.com"
+
+        private val regionalUriRegex = Regex(pattern = "(?<protocol>\\w+):[\\w-]+\\.xirsys\\.com(?<query>.*)")
+        private val regionalUriReplace = "\${protocol}://global.xirsys.net\${query}"
+        fun normalizeAndReplaceUriWithGlobal(regionalUri: String) =
+            regionalUriRegex.replace(input = regionalUri, replacement = regionalUriReplace)
     }
 
     private val xirsysClient: XirsysClient = RestClientBuilder.newBuilder()
@@ -103,7 +108,7 @@ class XirsysSessionHandler(
                             // A sample response looks like "stun:fr-turn1.xirsys.com"
                             // The java URI class fails to read host and port due to the missing // after the :
                             // Thus we "normalize" the uri, even though it is technically valid
-                            url.replaceFirst(":", "://")
+                            normalizeAndReplaceUriWithGlobal(url)
                         },
                     ),
                 )

--- a/src/test/kotlin/com/faforever/icebreaker/service/xirsys/XirsysSessionHandlerTest.kt
+++ b/src/test/kotlin/com/faforever/icebreaker/service/xirsys/XirsysSessionHandlerTest.kt
@@ -1,0 +1,15 @@
+package com.faforever.icebreaker.service.xirsys
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class XirsysSessionHandlerTest {
+    @Test
+    fun `it should replace xirsys urls with global one and normalize the protocol`() {
+        val input = "stun:fr-turn1.xirsys.com"
+
+        val result = XirsysSessionHandler.normalizeAndReplaceUriWithGlobal(input)
+
+        assertEquals("stun://global.xirsys.net", result)
+    }
+}


### PR DESCRIPTION
Still waiting for feedback from Xirsys if there is a better way than regex.