### PR TITLE
Use an external lock around getting the session id

### DIFF
--- a/src/main/kotlin/com/faforever/icebreaker/web/SessionController.kt
+++ b/src/main/kotlin/com/faforever/icebreaker/web/SessionController.kt
@@ -17,15 +17,20 @@ class SessionController(private val sessionService: SessionService) {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/game/{gameId}")
     @PermissionsAllowed("USER:lobby")
-    fun getSession(@RestPath gameId: Long): Session =
-        sessionService.getSession(gameId)
+    fun getSession(@RestPath gameId: Long): Session {
+        val sessionId: String
+        sessionService.lockGameId(gameId).use {
+            sessionId = sessionService.getSessionId(gameId)
+        }
+        return sessionService.getSession(sessionId)
+    }
 
     @GET
     @Produces(MEDIA_TYPE_JSON_API)
     @Path("/game/{gameId}")
     @PermissionsAllowed("USER:lobby")
     fun getSessionJsonApi(@RestPath gameId: Long): JsonApiResponse =
-        sessionService.getSession(gameId).let {
+        getSession(gameId).let {
             JsonApiResponse.fromObject(
                 JsonApiObject(
                     type = "iceSession",

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,8 +33,10 @@ xirsys:
   channel-namespace: "faf"
 
 "%dev":
-   quarkus:
-     log:
-       category:
-         "org.hibernate.SQL":
-           level: DEBUG
+  quarkus:
+    log:
+      category:
+        "org.hibernate.SQL":
+          level: DEBUG
+        "com.faforever":
+          level: DEBUG


### PR DESCRIPTION
This takes the lock out of the transaction since releasing the lock before the transaction is committed does us no good.

The one caveat here is that in order for this to work we have to somehow lock the retrieval of the session id to a single mariadb session, otherwise the connection pool could switch sessions between the get and release lock and then the releasing of the lock would fail