### PR TITLE
Degrade gracefully when Hetzner firewall sync fails

### DIFF
--- a/src/main/kotlin/com/faforever/icebreaker/persistence/TurnServerEntity.kt
+++ b/src/main/kotlin/com/faforever/icebreaker/persistence/TurnServerEntity.kt
@@ -24,6 +24,7 @@ data class TurnServerEntity(
     val presharedKey: String,
     val contactEmail: String,
     val active: Boolean,
+    val hetznerFirewall: Boolean,
 ) : PanacheEntityBase
 
 @Singleton

--- a/src/main/kotlin/com/faforever/icebreaker/service/SessionHandler.kt
+++ b/src/main/kotlin/com/faforever/icebreaker/service/SessionHandler.kt
@@ -4,11 +4,12 @@ interface SessionHandler {
     val active: Boolean
 
     /**
-     * Creates a new session for [id], connecting from [clientIp].
+     * Creates a new session for [id], connecting from [clientIp], and returns the servers
+     * that were successfully provisioned for it.
      *
      * [clientIp] is e.g. "88.217.205.180" or "2001:a61:9c01:11ab:c91e:c468:b262:3442".
      */
-    fun createSession(id: String, userId: Long, clientIp: String)
+    fun createSession(id: String, userId: Long, clientIp: String): List<Session.Server>
 
     // Remove an entire session
     fun deleteSession(id: String)
@@ -17,6 +18,4 @@ interface SessionHandler {
     fun deletePeerSession(id: String, userId: Long)
 
     fun getIceServers(): List<Server>
-
-    fun getIceServersSession(sessionId: String): List<Session.Server>
 }

--- a/src/main/kotlin/com/faforever/icebreaker/service/SessionService.kt
+++ b/src/main/kotlin/com/faforever/icebreaker/service/SessionService.kt
@@ -103,9 +103,13 @@ class SessionService(
         val currentUserId = currentUserService.requireCurrentUserId()
         val currentUserIp = currentUserService.getCurrentUserIp()
         val servers =
-            activeSessionHandlers.flatMap {
-                it.createSession(sessionId, currentUserId, currentUserIp)
-                it.getIceServersSession(sessionId)
+            activeSessionHandlers.flatMap { handler ->
+                try {
+                    handler.createSession(sessionId, currentUserId, currentUserIp)
+                } catch (e: Exception) {
+                    LOG.warn("Session handler {} failed to create a session; omitting its servers", handler::class.simpleName, e)
+                    emptyList()
+                }
             }
 
         AsyncRunner.runLater {
@@ -152,7 +156,13 @@ class SessionService(
                 instant = cleanupTime,
             ).forEach { iceSession ->
                 LOG.debug("Cleaning up session id ${iceSession.id}")
-                activeSessionHandlers.forEach { it.deleteSession(iceSession.id) }
+                activeSessionHandlers.forEach { handler ->
+                    try {
+                        handler.deleteSession(iceSession.id)
+                    } catch (e: Exception) {
+                        LOG.warn("Session handler {} failed to delete session {}; continuing cleanup", handler::class.simpleName, iceSession.id, e)
+                    }
+                }
 
                 gameUserStatsRepository.deleteByGameId(iceSession.gameId)
                 iceSessionRepository.delete(iceSession)
@@ -220,7 +230,13 @@ class SessionService(
 
         val sessionId = buildSessionId(gameId)
         if (eventMessage is PeerClosingMessage) {
-            activeSessionHandlers.forEach { it.deletePeerSession(sessionId, currentUserId) }
+            activeSessionHandlers.forEach { handler ->
+                try {
+                    handler.deletePeerSession(sessionId, currentUserId)
+                } catch (e: Exception) {
+                    LOG.warn("Session handler {} failed to delete peer session for {}; ignoring", handler::class.simpleName, sessionId, e)
+                }
+            }
         }
 
         rabbitmqEventEmitter.send(eventMessage)

--- a/src/main/kotlin/com/faforever/icebreaker/service/cloudflare/CloudflareSessionHandler.kt
+++ b/src/main/kotlin/com/faforever/icebreaker/service/cloudflare/CloudflareSessionHandler.kt
@@ -29,10 +29,6 @@ class CloudflareSessionHandler(
         LOG.info("CloudflareSessionHandler active: $active, turnEnabled: $turnEnabled")
     }
 
-    override fun createSession(id: String, userId: Long, clientIp: String) {
-        // Cloudflare has no session handling, we use global access
-    }
-
     override fun deleteSession(id: String) {
         // Cloudflare has no session handling, we use global access
     }
@@ -43,11 +39,13 @@ class CloudflareSessionHandler(
 
     override fun getIceServers() = listOf(Server(id = SERVER_NAME, region = "Global"))
 
-    override fun getIceServersSession(sessionId: String): List<Session.Server> =
+    // Cloudflare has no session handling (we use global access), so we simply request
+    // credentials and return the servers.
+    override fun createSession(id: String, userId: Long, clientIp: String): List<Session.Server> =
         cloudflareApiAdapter.requestIceServers(
             credentialRequest = CloudflareApiClient.CredentialRequest(
                 ttl = fafProperties.tokenLifetimeSeconds(),
-                customIdentifier = sessionId,
+                customIdentifier = id,
             ),
         ).let {
             listOf(

--- a/src/main/kotlin/com/faforever/icebreaker/service/hetzner/StubHetznerApiClient.kt
+++ b/src/main/kotlin/com/faforever/icebreaker/service/hetzner/StubHetznerApiClient.kt
@@ -4,6 +4,7 @@ import com.faforever.icebreaker.service.hetzner.SetFirewallRulesRequest.Firewall
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.inject.Alternative
 import org.eclipse.microprofile.rest.client.inject.RestClient
+import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -17,9 +18,16 @@ class StubHetznerApiClient : HetznerApiClient {
     private val callCount = AtomicInteger(0)
     private val rulesByFirewallId: MutableMap<String, List<FirewallRule>> = ConcurrentHashMap()
 
+    /** When set, [setFirewallRules] throws to simulate a failing Hetzner API (e.g. a 403). */
+    @Volatile
+    var failRequests: Boolean = false
+
     override fun setFirewallRules(id: String, request: SetFirewallRulesRequest): SetFirewallRulesResponse {
-        rulesByFirewallId[id] = request.rules
         callCount.incrementAndGet()
+        if (failRequests) {
+            throw IOException("Simulated Hetzner API failure")
+        }
+        rulesByFirewallId[id] = request.rules
         return SetFirewallRulesResponse(listOf())
     }
 
@@ -29,5 +37,11 @@ class StubHetznerApiClient : HetznerApiClient {
 
     fun resetCallCount() {
         callCount.set(0)
+    }
+
+    fun reset() {
+        callCount.set(0)
+        rulesByFirewallId.clear()
+        failRequests = false
     }
 }

--- a/src/main/kotlin/com/faforever/icebreaker/service/turn/TurnSessionHandler.kt
+++ b/src/main/kotlin/com/faforever/icebreaker/service/turn/TurnSessionHandler.kt
@@ -34,19 +34,23 @@ class TurnSessionHandler(
         LOG.info("TurnSessionHandler active: $active")
     }
 
-    override fun createSession(id: String, userId: Long, clientIp: String) = hetznerFirewallService.whitelistIpForSession(id, userId, clientIp)
+    override fun createSession(id: String, userId: Long, clientIp: String): List<Session.Server> {
+        val firewallSynced =
+            try {
+                hetznerFirewallService.whitelistIpForSession(id, userId, clientIp)
+                true
+            } catch (e: Exception) {
+                LOG.warn("Failed to sync Hetzner firewall for session {}; omitting firewalled TURN servers", id, e)
+                false
+            }
 
-    override fun deleteSession(id: String) = hetznerFirewallService.removeWhitelistsForSession(id)
-
-    override fun deletePeerSession(id: String, userId: Long) = hetznerFirewallService.removeWhitelistForSessionUser(sessionId = id, userId = userId)
-
-    override fun getIceServers() = turnServerRepository.findActive().map { Server(id = it.host, region = it.region) }
-
-    override fun getIceServersSession(sessionId: String): List<Session.Server> =
-        turnServerRepository
+        return turnServerRepository
             .findActive()
+            // On firewall sync failure, the client's IP isn't whitelisted, so it can't
+            // reach the firewalled servers. Omit those but keep the non-firewalled ones.
+            .filter { firewallSynced || !it.hetznerFirewall }
             .map {
-                val (tokenName, tokenSecret) = buildHmac(sessionId, securityIdentity.getUserId(), it.presharedKey)
+                val (tokenName, tokenSecret) = buildHmac(id, securityIdentity.getUserId(), it.presharedKey)
                 Session.Server(
                     id = it.host,
                     username = tokenName,
@@ -54,6 +58,13 @@ class TurnSessionHandler(
                     urls = buildUrls(turnServer = it),
                 )
             }
+    }
+
+    override fun deleteSession(id: String) = hetznerFirewallService.removeWhitelistsForSession(id)
+
+    override fun deletePeerSession(id: String, userId: Long) = hetznerFirewallService.removeWhitelistForSessionUser(sessionId = id, userId = userId)
+
+    override fun getIceServers() = turnServerRepository.findActive().map { Server(id = it.host, region = it.region) }
 
     private fun buildHmac(
         sessionName: String,

--- a/src/main/kotlin/com/faforever/icebreaker/service/xirsys/XirsysSessionHandler.kt
+++ b/src/main/kotlin/com/faforever/icebreaker/service/xirsys/XirsysSessionHandler.kt
@@ -29,9 +29,10 @@ class XirsysSessionHandler(
         LOG.info("XirsysSessionHandler active: $active, turnEnabled: $turnEnabled")
     }
 
-    override fun createSession(id: String, userId: Long, clientIp: String) {
+    override fun createSession(id: String, userId: Long, clientIp: String): List<Session.Server> {
         LOG.debug("Creating session id $id")
         xirsysApiAdapter.createChannel(id)
+        return requestIceServers(id)
     }
 
     override fun deleteSession(id: String) {
@@ -45,7 +46,7 @@ class XirsysSessionHandler(
 
     override fun getIceServers() = listOf(Server(id = SERVER_NAME, region = "Global"))
 
-    override fun getIceServersSession(sessionId: String): List<Session.Server> = xirsysApiAdapter.requestIceServers(
+    private fun requestIceServers(sessionId: String): List<Session.Server> = xirsysApiAdapter.requestIceServers(
         channelName = sessionId,
         turnRequest = TurnRequest(expire = fafProperties.tokenLifetimeSeconds()),
     ).iceServers.let {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,9 @@ quarkus:
         global: ignore
   flyway:
     migrate-at-start: true
+    # Allow rolling back to older app versions even if the database
+    # already contains newer (backward compatible) migrations.
+    ignore-migration-patterns: "*:future"
   oidc:
     auth-server-url: ${HYDRA_URL:https://hydra.faforever.com}
     # A tenant for our self-signed JWTs

--- a/src/main/resources/db/migration/V1.5.0__turn_server_hetzner_firewall.sql
+++ b/src/main/resources/db/migration/V1.5.0__turn_server_hetzner_firewall.sql
@@ -1,0 +1,3 @@
+alter table turn_servers
+    add hetzner_firewall boolean default false not null
+        comment 'Whether this TURN server sits behind the Hetzner cloud firewall and needs IP whitelisting';

--- a/src/test/kotlin/com/faforever/icebreaker/service/SessionServiceTest.kt
+++ b/src/test/kotlin/com/faforever/icebreaker/service/SessionServiceTest.kt
@@ -10,11 +10,13 @@ import io.quarkus.test.InjectMock
 import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.security.TestSecurity
 import io.quarkus.test.security.jwt.Claim
+import io.quarkus.test.security.jwt.ClaimType
 import io.quarkus.test.security.jwt.JwtSecurity
 import io.vertx.core.http.HttpServerRequest
 import jakarta.inject.Inject
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
 import org.eclipse.microprofile.rest.client.inject.RestClient
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -55,7 +57,7 @@ class SessionServiceTest {
             .thenReturn(testIp)
 
         iceSessionRepository.deleteAll()
-        hetznerApi.resetCallCount()
+        hetznerApi.reset()
         firewallWhitelistRepository.deleteAll()
     }
 
@@ -63,7 +65,7 @@ class SessionServiceTest {
     @JwtSecurity(
         claims = [
             Claim(key = "sub", value = "123"),
-            Claim(key = "scp", value = "[lobby]"),
+            Claim(key = "scp", value = """["lobby"]""", type = ClaimType.JSON_ARRAY),
             Claim(key = "ext", value = """{"roles":["USER"],"gameId":200}"""),
         ],
     )
@@ -80,7 +82,7 @@ class SessionServiceTest {
     @JwtSecurity(
         claims = [
             Claim(key = "sub", value = "123"),
-            Claim(key = "scp", value = "[lobby]"),
+            Claim(key = "scp", value = """["lobby"]""", type = ClaimType.JSON_ARRAY),
             Claim(key = "ext", value = """{"roles":["USER"],"gameId":201}"""),
         ],
     )
@@ -105,7 +107,7 @@ class SessionServiceTest {
     @JwtSecurity(
         claims = [
             Claim(key = "sub", value = "123"),
-            Claim(key = "scp", value = "[lobby]"),
+            Claim(key = "scp", value = """["lobby"]""", type = ClaimType.JSON_ARRAY),
             Claim(key = "ext", value = """{"roles":["USER"],"gameId":201}"""),
         ],
     )
@@ -128,7 +130,7 @@ class SessionServiceTest {
     @JwtSecurity(
         claims = [
             Claim(key = "sub", value = "123"),
-            Claim(key = "scp", value = "[lobby]"),
+            Claim(key = "scp", value = """["lobby"]""", type = ClaimType.JSON_ARRAY),
             Claim(key = "ext", value = """{"roles":["USER"],"gameId":201}"""),
         ],
     )
@@ -144,5 +146,21 @@ class SessionServiceTest {
 
         val whitelistedIps = hetznerApi.getRulesByFirewallId("fwid")!!.flatMap { it.sourceIps }.toSet()
         assertThat(whitelistedIps).contains("$testIp/32")
+    }
+
+    @TestSecurity(user = "testUser", roles = ["viewer"])
+    @JwtSecurity(
+        claims = [
+            Claim(key = "sub", value = "123"),
+            Claim(key = "scp", value = """["lobby"]""", type = ClaimType.JSON_ARRAY),
+            Claim(key = "ext", value = """{"roles":["USER"],"gameId":202}"""),
+        ],
+    )
+    @Test
+    fun `getSession succeeds when Hetzner firewall sync fails`() {
+        hetznerApi.failRequests = true
+
+        // The Hetzner sync fails, but the request must not blow up with a 500.
+        assertThatCode { service.getSession(202L) }.doesNotThrowAnyException()
     }
 }

--- a/src/test/kotlin/com/faforever/icebreaker/web/SessionControllerTest.kt
+++ b/src/test/kotlin/com/faforever/icebreaker/web/SessionControllerTest.kt
@@ -3,15 +3,18 @@ package com.faforever.icebreaker.web
 import com.faforever.icebreaker.persistence.FirewallWhitelistRepository
 import com.faforever.icebreaker.persistence.TurnServerEntity
 import com.faforever.icebreaker.persistence.TurnServerRepository
+import com.faforever.icebreaker.service.hetzner.StubHetznerApiClient
 import io.quarkus.test.junit.QuarkusTest
 import io.restassured.RestAssured.given
 import jakarta.inject.Inject
 import jakarta.transaction.Transactional
 import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.rest.client.inject.RestClient
 import org.hamcrest.Matchers.emptyString
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.greaterThan
 import org.hamcrest.Matchers.not
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -25,6 +28,10 @@ class SessionControllerTest {
 
     @Inject
     lateinit var firewallWhitelistRepository: FirewallWhitelistRepository
+
+    @Inject
+    @RestClient
+    lateinit var hetznerApi: StubHetznerApiClient
 
     val gameId = 100L
     val testJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxIiwiZXh0Ijp7InJvbGVzIjpbIlVTRVIiXSwiZ2FtZUlkIjoxMDB9LCJzY3AiOlsibG9iYnkiXSwiaXNzIjoiaHR0cHM6Ly9pY2UuZmFmb3JldmVyLmNvbSIsImF1ZCI6Imh0dHBzOi8vaWNlLmZhZm9yZXZlci5jb20iLCJleHAiOjIwMDAwMDAwMDAsImlhdCI6MTc0MTAwMDAwMCwianRpIjoiMDE5YjBmMDYtOGJlYi00NzEyLWFiNWUtNGUyNmVjMTM0YjFlIn0.CHEtH0I-BacvjIc_a8ZSKcXMmRZqObGIqScs8BNbZrcje9GVvnTeJEkOxh3Lpo0C1Cm8_x_YQ-zilMTmVu87ZH31_FRYvJuaU9gjo3izmHcncWmSOpjg2n8BtkPXcnggdxM5DW7bPUytkgPGhvFUbeTNRw0Lv1Atb9L2NcW33jhQ-jz-3Ev0fVfgAzJMxrhDCpoCw4QMk6doEIbmJ0Egl1-9AHyr3jd1PXMQAI2K3dX2v0hUmOJ2MxClukUFXkXRp76ZJ9L594YU1gLlIprcuPtRQCIvgJ_gD2Cd6iPQHAUFFvNFmpyLVDU3fgrznWIRkcu2CWSlybhFHCvx5Eldhg"
@@ -46,6 +53,7 @@ class SessionControllerTest {
                 presharedKey = "test-preshared-key-123",
                 contactEmail = "test@example.com",
                 active = true,
+                hetznerFirewall = true,
             ),
         )
         turnServerRepository.persist(
@@ -60,6 +68,7 @@ class SessionControllerTest {
                 presharedKey = "test-preshared-key-456",
                 contactEmail = "test2@example.com",
                 active = true,
+                hetznerFirewall = false,
             ),
         )
         turnServerRepository.persist(
@@ -74,8 +83,14 @@ class SessionControllerTest {
                 presharedKey = "disabled-key",
                 contactEmail = "disabled@example.com",
                 active = false,
+                hetznerFirewall = true,
             ),
         )
+    }
+
+    @AfterEach
+    fun resetHetznerStub() {
+        hetznerApi.reset()
     }
 
     @Test
@@ -104,5 +119,21 @@ class SessionControllerTest {
         val allowedIps = firewallWhitelistRepository.getForSessionId("game/100")
         assertThat(allowedIps).hasSize(1)
         assertThat(allowedIps[0].allowedIp).isEqualTo("127.0.0.1")
+    }
+
+    @Test
+    fun `GET session-game-(game) omits firewalled servers when Hetzner sync fails`() {
+        hetznerApi.failRequests = true
+
+        given()
+            .header("Authorization", "Bearer $testJwt")
+            .`when`().get("/session/game/$gameId")
+            .then()
+            // The firewall sync fails, but the request still succeeds ...
+            .statusCode(200)
+            .body("id", equalTo("100"))
+            // ... returning only the non-firewalled server, omitting the firewalled one.
+            .body("servers.size()", equalTo(1))
+            .body("servers[0].id", equalTo("turn2.test.example.com"))
     }
 }


### PR DESCRIPTION
## Problem

When `HetznerFirewallUpdater.syncFirewallWithHetzner()` fails (e.g. Hetzner returns 403), the failure propagated out of `TurnSessionHandler.createSession()` and turned **every** session/TURN-server request into a 500 — taking down all providers, not just Hetzner.

The exception bubbled through `SessionService.getSession()`'s `flatMap`, aborting the whole request, so no provider's servers (Cloudflare/Xirsys included) were returned.

## Fix

- **Isolate each session handler** in `SessionService` (`getSession`, `cleanUpSessions`, and the peer-closing path in `onMessageReceived`) so one provider's failure can no longer break the others, the cleanup loop, or a peer-teardown request.
- **Omit only the affected servers**: the TURN handler drops just the servers that actually sit behind the Hetzner firewall when the sync fails, while still returning the rest. Firewalled servers are identified by a new `turn_servers.hetzner_firewall` flag.
- **Merge provisioning + listing**: `SessionHandler.createSession(...)` now returns the `List<Session.Server>` it provisioned, replacing the separate `getIceServersSession` call, so the firewall outcome directly determines the returned set (no shared cross-call state).
- **Test cleanup**: fix the `scp` test claims to be a real JSON array (`ClaimType.JSON_ARRAY`) instead of the literal string `"[lobby]"` that the DEFAULT claim type was silently producing.

## ⚠️ Operational follow-up (required)

Existing `turn_servers` rows default to `hetzner_firewall = false`, so the omit-on-failure behavior only takes effect once the real Hetzner-firewalled servers are flagged. In the same deploy/maintenance window run:

```sql
UPDATE turn_servers SET hetzner_firewall = true WHERE host IN (...);
```

## Testing

- Full suite passes (23 tests) against the project's compose stack.
- New tests: `getSession` returns **200 with only the non-firewalled server** (and doesn't throw) when Hetzner sync fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying TURN servers protected by a cloud firewall.
  * Session creation now returns available ICE servers directly.
  * Firewalled TURN servers are excluded when access synchronization fails.

* **Bug Fixes**
  * Session creation and cleanup now continue when an individual server provider fails.
  * Improved compatibility when rolling back to older application versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->